### PR TITLE
Compose flask nginx fixflaskentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Migrating a Flask Application to GC Images
 
 This branch shows a Docker Compose orchestration between a containerized Flask application and the nginx Chainguard Image.
+
+Start with:
+
+```bash
+docker compose up
+```
+The application should be visible at both `0.0.0.0` and `0.0.0.0:80`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Migrating a Flask Application to GC Images
 
-Sample application showing a migration to Chainguard Images for a Flask application. You can view the pre-migration app at the [v0 branch](https://github.com/chainguard-dev/cg-images-python-migration/tree/v0).
+This branch shows a Docker Compose orchestration between a containerized Flask application and the nginx Chainguard Image.

--- a/flask-app/Dockerfile
+++ b/flask-app/Dockerfile
@@ -19,6 +19,6 @@ ENV PATH="/flask-app/venv/bin:$PATH"
 
 EXPOSE 8000
 
-ENTRYPOINT ["python",, "-m", "gunicorn", "-b", "0.0.0.0:8000", "app:app"]
+ENTRYPOINT ["python", "-m", "gunicorn", "-b", "0.0.0.0:8000", "app:app"]
 
 

--- a/flask-app/Dockerfile
+++ b/flask-app/Dockerfile
@@ -17,10 +17,8 @@ COPY app.py app.py
 COPY --from=dev /flask-app/venv /flask-app/venv
 ENV PATH="/flask-app/venv/bin:$PATH"
 
-EXPOSE 5000
+EXPOSE 8000
 
-
-ENTRYPOINT ["python"]
-CMD ["-m", "gunicorn", "-b", "0.0.0.0:8000", "app:app"]
+ENTRYPOINT ["python",, "-m", "gunicorn", "-b", "0.0.0.0:8000", "app:app"]
 
 


### PR DESCRIPTION
there was an extra comma in the entrypoint that would make the container look for the /bin/sh shell. Removing the comma allows the docker compose up command to work as expected.